### PR TITLE
:green_heart: Fixed Windows CI builds

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -90,8 +90,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
           -DBoost_ADDITIONAL_VERSIONS=1.80.0
-        env:
-          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
+          -DBOOST_ROOT=${{steps.install-boost.outputs.BOOST_ROOT}}
 
       - name: Build quicksim-siqad-plugin
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,9 +60,9 @@ jobs:
 
       - name: Test for Boost directories
         run: |
-          ls -la ${{steps.install-boost.outputs.BOOST_ROOT}}\include
-          ls -la ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost
-          ls -la ${{steps.install-boost.outputs.BOOST_ROOT}}\lib
+          Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include
+          Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost
+          Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\lib
 
       - name: Clone Repository
         uses: actions/checkout@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -86,7 +86,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
         env:
-          -DBOOST_ROOT=${{steps.install-boost.outputs.BOOST_ROOT}}
+        BOOST_ROOT: ${{steps.install-boost.outputs.BOOST_ROOT}}
           -DBOOST_INCLUDEDIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include
           -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include
           -DBoost_LIBRARY_DIRS=${{steps.install-boost.outputs.BOOST_ROOT}}\lib

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,12 +38,9 @@ jobs:
           - os: windows-2022
             env: 'Visual Studio 17 2022'
           - toolset: v142
-            boost_toolset: msvc
+            boost_platform: 2019
           - toolset: v143
-            boost_toolset: msvc
             boost_platform: 2022
-          - toolset: ClangCL
-            boost_toolset: clang
         exclude:
           - os: windows-2019
             toolset: v143
@@ -60,7 +57,7 @@ jobs:
         with:
           boost_version: 1.78.0
           platform_version: ${{matrix.boost_platform}}
-          toolset: ${{matrix.boost_toolset}}
+          toolset: msvc
           cache: true
 
       - name: Clone Repository

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,13 +60,13 @@ jobs:
           cache: true
           arch: x86
 
-      - name: Test for Boost directories
-        run: |
-          ls -la ${{steps.install-boost.outputs.BOOST_ROOT}}\include
-          ls -la ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost
-          cat ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost\version.hpp
-          ls -la Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost-1_80\boost
-          ls -la Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\lib
+#      - name: Test for Boost directories
+#        run: |
+#          ls -la ${{steps.install-boost.outputs.BOOST_ROOT}}\include
+#          ls -la ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost
+#          cat ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost\version.hpp
+#          ls -la Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost-1_80\boost
+#          ls -la Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\lib
 
       - name: Clone Repository
         uses: actions/checkout@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -84,6 +84,8 @@ jobs:
         run: >
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+          -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include
+          -DBoost_LIBRARY_DIRS=${{steps.install-boost.outputs.BOOST_ROOT}}\lib
           -DQUICKSIM_TEST=ON
 
       - name: Build quicksim-siqad-plugin

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -89,7 +89,7 @@ jobs:
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
-          -DBoost_ADDITIONAL_VERSIONS=1.80.0
+          -DBoost_ADDITIONAL_VERSIONS="1.80.0"
           -DBOOST_ROOT=${{steps.install-boost.outputs.BOOST_ROOT}}
           -DBOOST_INCLUDEDIR=${{steps.install-boost.outputs.BOOST_ROOT}}/include
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -91,6 +91,7 @@ jobs:
           -DQUICKSIM_TEST=ON
           -DBoost_ADDITIONAL_VERSIONS=1.80.0
           -DBOOST_ROOT=${{steps.install-boost.outputs.BOOST_ROOT}}
+          -DBOOST_INCLUDEDIR=${{steps.install-boost.outputs.BOOST_ROOT}}/include
 
       - name: Build quicksim-siqad-plugin
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -63,7 +63,8 @@ jobs:
         run: |
           Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include
           Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost
-          Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost-1_80
+          Get-Content -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost\version.hpp
+          Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost-1_80\boost
           Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\lib
 
       - name: Clone Repository

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,6 +21,10 @@ on:
       - '.github/workflows/windows.yml'
     merge_group:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build_and_test:
     strategy:
@@ -58,11 +62,11 @@ jobs:
 
       - name: Test for Boost directories
         run: |
-          Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include
-          Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost
-          Get-Content -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost\version.hpp
-          Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost-1_80\boost
-          Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\lib
+          ls -la ${{steps.install-boost.outputs.BOOST_ROOT}}\include
+          ls -la ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost
+          cat ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost\version.hpp
+          ls -la Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost-1_80\boost
+          ls -la Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\lib
 
       - name: Clone Repository
         uses: actions/checkout@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,8 +34,16 @@ jobs:
         include:
           - os: windows-2019
             env: 'Visual Studio 16 2019'
+            boost_platform: 2019
           - os: windows-2022
             env: 'Visual Studio 17 2022'
+          - toolset: v142
+            boost_toolset: msvc
+          - toolset: v143
+            boost_toolset: msvc
+            boost_platform: 2022
+          - toolset: ClangCL
+            boost_toolset: clang
         exclude:
           - os: windows-2019
             toolset: v143
@@ -46,16 +54,14 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - name: Install Chocolatey
-        run: |
-          Set-ExecutionPolicy Bypass -Scope Process -Force;
-          [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-
-      - name: Upgrade Chocolatey
-        run: choco upgrade chocolatey -y
-
       - name: Install Boost
-        run: choco install boost
+        uses: MarkusJx/install-boost@v2.4.1
+        id: install-boost
+        with:
+          boost_version: 1.73.0
+          platform_version: ${{matrix.boost_platform}}
+          toolset: ${{matrix.boost_toolset}}
+          cache: true
 
       - name: Clone Repository
         uses: actions/checkout@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -88,8 +88,8 @@ jobs:
         run: >
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
-          -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost
           -DQUICKSIM_TEST=ON
+          -DBoost_ADDITIONAL_VERSIONS=1.80.0
         env:
           BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -78,8 +78,6 @@ jobs:
         run: cmake -E make_directory ${{github.workspace}}\build
 
       - name: Configure CMake
-        env:
-          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
         working-directory: ${{github.workspace}}\build
         run: >
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
@@ -87,6 +85,8 @@ jobs:
           -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include
           -DBoost_LIBRARY_DIRS=${{steps.install-boost.outputs.BOOST_ROOT}}\lib
           -DQUICKSIM_TEST=ON
+        env:
+          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
 
       - name: Build quicksim-siqad-plugin
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -82,7 +82,7 @@ jobs:
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
-          -DBoost_INCLUDE_DIR=${{github.workspace}}
+          -DBOOST_ROOT=${{github.workspace}}\boost
 
       - name: Build quicksim-siqad-plugin
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,10 +21,6 @@ on:
       - '.github/workflows/windows.yml'
     merge_group:
 
-defaults:
-  run:
-    shell: pwsh  # use pwsh as directory handling does not seem to work with bash
-
 jobs:
   build_and_test:
     strategy:
@@ -58,6 +54,7 @@ jobs:
           platform_version: ${{matrix.boost_platform}}
           toolset: msvc
           cache: true
+          arch: x86
 
       - name: Test for Boost directories
         run: |
@@ -89,10 +86,10 @@ jobs:
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
-          -DBoost_ADDITIONAL_VERSIONS="1.80.0"
-          -DBOOST_ROOT=${{steps.install-boost.outputs.BOOST_ROOT}}
-          -DBOOST_INCLUDEDIR=${{steps.install-boost.outputs.BOOST_ROOT}}/include
-          -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}/include
+          -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}/include\
+          -DBoost_LIBRARY_DIRS=${{steps.install-boost.outputs.BOOST_ROOT}}/lib
+        env:
+          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
 
       - name: Build quicksim-siqad-plugin
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Install Boost
-        uses: MarkusJx/install-boost@v2.4.1
+        uses: MarkusJx/install-boost@v2.4.4
         id: install-boost
         with:
           boost_version: 1.80.0

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -80,7 +80,6 @@ jobs:
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include
-          -DBoost_LIBRARY_DIRS=${{steps.install-boost.outputs.BOOST_ROOT}}\lib
           -DQUICKSIM_TEST=ON
         env:
           BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Upgrade Chocolatey
         run: choco upgrade chocolatey -y
 
-      - name: Install Boost and TBB
-        run: choco install boost tbb
+      - name: Install Boost
+        run: choco install boost
 
       - name: Clone Repository
         uses: actions/checkout@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -86,10 +86,10 @@ jobs:
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
-          -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}/include\
+          -DBOOST_ROOT=${{steps.install-boost.outputs.BOOST_ROOT}}
+          -DBOOST_INCLUDEDIR=${{steps.install-boost.outputs.BOOST_ROOT}}/include
+          -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}/include
           -DBoost_LIBRARY_DIRS=${{steps.install-boost.outputs.BOOST_ROOT}}/lib
-        env:
-          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
 
       - name: Build quicksim-siqad-plugin
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,7 +53,7 @@ jobs:
         uses: MarkusJx/install-boost@v2.4.1
         id: install-boost
         with:
-          boost_version: 1.78.0
+          boost_version: 1.80.0
           platform_version: ${{matrix.boost_platform}}
           toolset: msvc
           cache: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,10 +21,6 @@ on:
       - '.github/workflows/windows.yml'
     merge_group:
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   build_and_test:
     strategy:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,6 @@ on:
 jobs:
   build_and_test:
     strategy:
-      fail-fast: false
       matrix:
         os: [ windows-2019, windows-2022 ]
         toolset: [ v142, v143, ClangCL ]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,9 +38,6 @@ jobs:
             boost_platform: 2019
           - os: windows-2022
             env: 'Visual Studio 17 2022'
-          - toolset: v142
-            boost_platform: 2019
-          - toolset: v143
             boost_platform: 2022
         exclude:
           - os: windows-2019

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -77,12 +77,15 @@ jobs:
         run: cmake -E make_directory ${{github.workspace}}\build
 
       - name: Configure CMake
+        env:
+          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
         working-directory: ${{github.workspace}}\build
         run: >
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
-          -DBOOST_ROOT=${{github.workspace}}\boost\boost\
+          -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include\
+          -DBoost_LIBRARY_DIRS=${{steps.install-boost.outputs.BOOST_ROOT}}\lib\
 
       - name: Build quicksim-siqad-plugin
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -70,7 +70,7 @@ jobs:
           max-size: 10G
 
       - name: Create Build Environment
-        run: cmake -E make_directory ${{github.workspace}}/build
+        run: cmake -E make_directory ${{github.workspace}}\build
 
       - name: Configure CMake
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,6 +46,11 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
+      - name: Clone Repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
       - name: Install Boost
         uses: MarkusJx/install-boost@v2.4.4
         id: install-boost
@@ -62,11 +67,6 @@ jobs:
 #          cat ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost\version.hpp
 #          ls -la Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost-1_80\boost
 #          ls -la Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\lib
-
-      - name: Clone Repository
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -85,9 +85,7 @@ jobs:
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
-          -DBOOST_INCLUDEDIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include
-          -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include
-          -DBoost_LIBRARY_DIRS=${{steps.install-boost.outputs.BOOST_ROOT}}\lib
+          -DBoost_USE_STATIC_RUNTIME=OFF
         env:
           BOOST_ROOT: ${{steps.install-boost.outputs.BOOST_ROOT}}
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,6 +58,12 @@ jobs:
           toolset: msvc
           cache: true
 
+      - name: Test for Boost directories
+        run: |
+          ls -la ${{steps.install-boost.outputs.BOOST_ROOT}}\include
+          ls -la ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost
+          ls -la ${{steps.install-boost.outputs.BOOST_ROOT}}\lib
+
       - name: Clone Repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -82,7 +82,7 @@ jobs:
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
-          -DBOOST_ROOT=${{github.workspace}}\boost
+          -DBOOST_ROOT=${{github.workspace}}\boost\boost\
 
       - name: Build quicksim-siqad-plugin
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -82,7 +82,7 @@ jobs:
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
-          -DBoost_INCLUDE_DIR=${{github.workspace}}\boost
+          -DBoost_INCLUDE_DIR=${{github.workspace}}
 
       - name: Build quicksim-siqad-plugin
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -82,7 +82,7 @@ jobs:
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
-          -Boost_INCLUDE_DIR=${{github.workspace}}\boost
+          -DBoost_INCLUDE_DIR=${{github.workspace}}\boost
 
       - name: Build quicksim-siqad-plugin
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,6 +27,7 @@ defaults:
 jobs:
   build_and_test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ windows-2019, windows-2022 ]
         toolset: [ v142, v143, ClangCL ]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -84,8 +84,8 @@ jobs:
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
-          -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include\
-          -DBoost_LIBRARY_DIRS=${{steps.install-boost.outputs.BOOST_ROOT}}\lib\
+          -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include
+          -DBoost_LIBRARY_DIRS=${{steps.install-boost.outputs.BOOST_ROOT}}\lib
 
       - name: Build quicksim-siqad-plugin
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,7 +58,7 @@ jobs:
         uses: MarkusJx/install-boost@v2.4.1
         id: install-boost
         with:
-          boost_version: 1.73.0
+          boost_version: 1.78.0
           platform_version: ${{matrix.boost_platform}}
           toolset: ${{matrix.boost_toolset}}
           cache: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,9 +52,8 @@ jobs:
         with:
           boost_version: 1.80.0
           platform_version: ${{matrix.boost_platform}}
-          toolset: msvc
           cache: true
-          arch: x86
+
 
 #      - name: Test for Boost directories
 #        run: |
@@ -86,6 +85,7 @@ jobs:
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
+        env:
           -DBOOST_ROOT=${{steps.install-boost.outputs.BOOST_ROOT}}
           -DBOOST_INCLUDEDIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include
           -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,15 +58,8 @@ jobs:
           boost_version: 1.80.0
           platform_version: ${{matrix.boost_platform}}
           cache: true
-
-
-#      - name: Test for Boost directories
-#        run: |
-#          ls -la ${{steps.install-boost.outputs.BOOST_ROOT}}\include
-#          ls -la ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost
-#          cat ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost\version.hpp
-#          ls -la Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost-1_80\boost
-#          ls -la Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\lib
+          toolset: msvc
+          arch: x86
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -85,10 +78,8 @@ jobs:
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
-          -DBoost_USE_STATIC_RUNTIME=OFF
         env:
           BOOST_ROOT: ${{steps.install-boost.outputs.BOOST_ROOT}}
-
 
       - name: Build quicksim-siqad-plugin
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -82,6 +82,7 @@ jobs:
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
+          -Boost_INCLUDE_DIR=${{github.workspace}}\boost
 
       - name: Build quicksim-siqad-plugin
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,6 +19,7 @@ on:
       - '**/CMakeLists.txt'
       - 'libs/**'
       - '.github/workflows/windows.yml'
+    merge_group:
 
 defaults:
   run:
@@ -62,6 +63,7 @@ jobs:
         run: |
           Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include
           Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost
+          Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost-1_80
           Get-ChildItem -Path ${{steps.install-boost.outputs.BOOST_ROOT}}\lib
 
       - name: Clone Repository
@@ -85,7 +87,7 @@ jobs:
         run: >
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
-          -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include
+          -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include\boost
           -DQUICKSIM_TEST=ON
         env:
           BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -85,11 +85,12 @@ jobs:
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
-        env:
-        BOOST_ROOT: ${{steps.install-boost.outputs.BOOST_ROOT}}
           -DBOOST_INCLUDEDIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include
           -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include
           -DBoost_LIBRARY_DIRS=${{steps.install-boost.outputs.BOOST_ROOT}}\lib
+        env:
+          BOOST_ROOT: ${{steps.install-boost.outputs.BOOST_ROOT}}
+
 
       - name: Build quicksim-siqad-plugin
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -84,8 +84,6 @@ jobs:
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
-          -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include
-          -DBoost_LIBRARY_DIRS=${{steps.install-boost.outputs.BOOST_ROOT}}\lib
 
       - name: Build quicksim-siqad-plugin
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -78,7 +78,7 @@ jobs:
           max-size: 10G
 
       - name: Create Build Environment
-        run: cmake -E make_directory ${{github.workspace}}\build
+        run: cmake -E make_directory ${{github.workspace}}/build
 
       - name: Configure CMake
         working-directory: ${{github.workspace}}\build
@@ -87,9 +87,9 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DQUICKSIM_TEST=ON
           -DBOOST_ROOT=${{steps.install-boost.outputs.BOOST_ROOT}}
-          -DBOOST_INCLUDEDIR=${{steps.install-boost.outputs.BOOST_ROOT}}/include
-          -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}/include
-          -DBoost_LIBRARY_DIRS=${{steps.install-boost.outputs.BOOST_ROOT}}/lib
+          -DBOOST_INCLUDEDIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include
+          -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}\include
+          -DBoost_LIBRARY_DIRS=${{steps.install-boost.outputs.BOOST_ROOT}}\lib
 
       - name: Build quicksim-siqad-plugin
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -92,6 +92,7 @@ jobs:
           -DBoost_ADDITIONAL_VERSIONS="1.80.0"
           -DBOOST_ROOT=${{steps.install-boost.outputs.BOOST_ROOT}}
           -DBOOST_INCLUDEDIR=${{steps.install-boost.outputs.BOOST_ROOT}}/include
+          -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}/include
 
       - name: Build quicksim-siqad-plugin
         working-directory: ${{github.workspace}}\build

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -16,8 +16,6 @@ if (QUICKSIM_TEST)
     add_subdirectory(Catch2/)
 endif ()
 
-set(Boost_DEBUG 1)
-
 # Require the Boost package
 find_package(Boost 1.70.0 REQUIRED)
 if (Boost_FOUND)

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -16,11 +16,6 @@ if (QUICKSIM_TEST)
     add_subdirectory(Catch2/)
 endif ()
 
-# Include Boost
-if (WIN32)
-    set(Boost_USE_STATIC_LIBS ON)
-endif ()
-
 # Require the Boost package
 find_package(Boost REQUIRED)
 if (Boost_FOUND)

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -24,7 +24,6 @@ if (Boost_FOUND)
     message(STATUS "Boost libraries have been found: ${Boost_VERSION}")
 
     # Link against Boost
-#    target_include_directories(dependencies SYSTEM INTERFACE ${Boost_INCLUDE_DIRS})
     target_link_libraries(dependencies INTERFACE Boost::boost)
 else ()
     message(FATAL_ERROR "Could not find Boost")

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -19,7 +19,7 @@ endif ()
 set(Boost_DEBUG 1)
 
 # Require the Boost package
-find_package(Boost COMPONENTS container)
+find_package(Boost)
 if (Boost_FOUND)
     message(STATUS "Boost libraries have been found: ${Boost_VERSION}")
 

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -16,6 +16,8 @@ if (QUICKSIM_TEST)
     add_subdirectory(Catch2/)
 endif ()
 
+set(Boost_DEBUG 1)
+
 # Require the Boost package
 find_package(Boost REQUIRED)
 if (Boost_FOUND)

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -25,9 +25,10 @@ endif ()
 find_package(Boost REQUIRED)
 if (Boost_FOUND)
     message(STATUS "Boost library has been found")
+
+    # Link against Boost
+    target_include_directories(dependencies SYSTEM INTERFACE ${Boost_INCLUDE_DIRS})
+    target_link_libraries(dependencies INTERFACE ${Boost_LIBRARY_DIRS})
 else ()
     message(FATAL_ERROR "Could not find Boost")
 endif ()
-
-# Link against Boost
-target_include_directories(dependencies SYSTEM INTERFACE ${Boost_INCLUDE_DIRS})

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -19,12 +19,13 @@ endif ()
 set(Boost_DEBUG 1)
 
 # Require the Boost package
-find_package(Boost)
+find_package(Boost 1.70.0 REQUIRED)
 if (Boost_FOUND)
     message(STATUS "Boost libraries have been found: ${Boost_VERSION}")
 
     # Link against Boost
-    target_include_directories(dependencies SYSTEM INTERFACE ${Boost_INCLUDE_DIRS})
+#    target_include_directories(dependencies SYSTEM INTERFACE ${Boost_INCLUDE_DIRS})
+    target_link_libraries(dependencies INTERFACE Boost::boost)
 else ()
     message(FATAL_ERROR "Could not find Boost")
 endif ()

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -19,13 +19,12 @@ endif ()
 set(Boost_DEBUG 1)
 
 # Require the Boost package
-find_package(Boost REQUIRED)
+find_package(Boost COMPONENTS container)
 if (Boost_FOUND)
-    message(STATUS "Boost library has been found")
+    message(STATUS "Boost libraries have been found: ${Boost_VERSION}")
 
     # Link against Boost
     target_include_directories(dependencies SYSTEM INTERFACE ${Boost_INCLUDE_DIRS})
-    target_link_libraries(dependencies INTERFACE ${Boost_LIBRARY_DIRS})
 else ()
     message(FATAL_ERROR "Could not find Boost")
 endif ()

--- a/src/interface.hpp
+++ b/src/interface.hpp
@@ -134,9 +134,8 @@ class quicksim_interface
 
             const auto iteration_steps = static_cast<uint64_t>(std::stoi(sqconn->getParameter("iteration_steps")));
             const auto alpha           = std::stod(sqconn->getParameter("alpha"));
-            
-            
-            // Check if number_threads is negative
+
+            // prevent number of threads to be negative
             if (const auto number_threads = static_cast<int64_t>(std::stod(sqconn->getParameter("num_threads")));
                 number_threads >= 0)
             {

--- a/src/interface.hpp
+++ b/src/interface.hpp
@@ -88,7 +88,7 @@ class quicksim_interface
         sqconn->writeResultsXml();
     }
 
-    [[nodiscard]] fiction::quicksim_params get_quicksim_params() const noexcept
+    [[nodiscard]] fiction::quicksim_params& get_quicksim_params() noexcept
     {
         return sim_par;
     }

--- a/src/interface.hpp
+++ b/src/interface.hpp
@@ -16,6 +16,8 @@
 #include <fiction/traits.hpp>
 #include <fiction/types.hpp>
 
+#include <fmt/format.h>
+
 #include <cmath>
 #include <cstdlib>
 #include <map>
@@ -118,22 +120,31 @@ class quicksim_interface
 
             layout.assign_cell_type({db->n, db->m, db->l}, fiction::sidb_cell_clk_lyt_siqad::cell_type::NORMAL);
 
-            log.debug() << "DB loc: x=" << db_locs.back().first << ", y=" << db_locs.back().second << std::endl;
+            log.debug() << fmt::format("DB loc: x={}, y={}", db_locs.back().first, db_locs.back().second) << std::endl;
         }
 
         fiction::sidb_simulation_parameters params{2};
 
-        // variables: physical
-        params.mu        = std::stod(sqconn->getParameter("muzm"));
-        params.epsilon_r = std::round(std::stod(sqconn->getParameter("eps_r")) * 100) / 100;  // round to two digits
-        params.lambda_tf = std::stod(sqconn->getParameter("debye_length"));
+        try
+        {
+            // variables: physical
+            params.mu        = std::stod(sqconn->getParameter("muzm"));
+            params.epsilon_r = std::round(std::stod(sqconn->getParameter("eps_r")) * 100) / 100;  // round to two digits
+            params.lambda_tf = std::stod(sqconn->getParameter("debye_length"));
 
-        const auto iteration_steps = static_cast<uint64_t>(std::stoi(sqconn->getParameter("iteration_steps")));
-        const auto alpha           = std::stod(sqconn->getParameter("alpha"));
+            const auto iteration_steps = static_cast<uint64_t>(std::stoi(sqconn->getParameter("iteration_steps")));
+            const auto alpha           = std::stod(sqconn->getParameter("alpha"));
 
-        log.echo() << "Retrieval from SiQADConn complete." << std::endl;
+            log.echo() << "Retrieval from SiQADConn complete." << std::endl;
 
-        sim_par = fiction::quicksim_params{params, iteration_steps, alpha};
+            sim_par = fiction::quicksim_params{params, iteration_steps, alpha};
+        }
+        catch (...)
+        {
+            log.critical() << "Could not retrieve all parameters from SiQADConn." << std::endl;
+
+            throw;
+        }
     }
 
     // Instances

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,17 +57,17 @@ int main(int argc, char* argv[])
 
     log.echo() << "\n*** Initiate QuickSim interface ***" << std::endl;
     log.echo() << "\n*** Read Simulation parameters ***" << std::endl;
-    auto interface = quicksim_interface{if_name, of_name, verbose};
+    auto qs_interface = quicksim_interface{if_name, of_name, verbose};
 
     log.echo() << "\n*** Invoke simulation ***" << std::endl;
     stopwatch.start();
-    interface.run_simulation();
+    qs_interface.run_simulation();
     stopwatch.end();
 
     log.echo() << "\n*** Write simulation results ***" << std::endl;
-    interface.write_sim_results();
+    qs_interface.write_sim_results();
 
-    log.echo() << "\n*** Quicksim Complete ***" << std::endl;
+    log.echo() << "\n*** QuickSim Complete ***" << std::endl;
 
     stopwatch.print_stopwatch(log_level);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,7 +57,7 @@ int main(int argc, char* argv[])
 
     log.echo() << "\n*** Initiate QuickSim interface ***" << std::endl;
     log.echo() << "\n*** Read Simulation parameters ***" << std::endl;
-    quicksim_interface interface(if_name, of_name, verbose);
+    auto interface = quicksim_interface{if_name, of_name, verbose};
 
     log.echo() << "\n*** Invoke simulation ***" << std::endl;
     stopwatch.start();

--- a/test/interface.cpp
+++ b/test/interface.cpp
@@ -14,9 +14,8 @@
 
 TEST_CASE("Test if reading, simulating, and creating a result-file works", "[interface]")
 {
-    quicksim_interface interface {
-        fmt::format("{}/sim_problem_0.xml", TEST_PATH), fmt::format("{}/sim_result_0.xml", TEST_PATH), false
-    };
+    quicksim_interface interface(fmt::format("{}/sim_problem_0.xml", TEST_PATH),
+                                 fmt::format("{}/sim_result_0.xml", TEST_PATH), false);
 
     CHECK(interface.get_quicksim_params().phys_params.lambda_tf == 5);
     CHECK(interface.get_quicksim_params().phys_params.epsilon_r == 5.6);

--- a/test/interface.cpp
+++ b/test/interface.cpp
@@ -14,35 +14,35 @@
 
 TEST_CASE("Test if reading, simulating, and creating a result-file works", "[interface]")
 {
-    auto interface = quicksim_interface{fmt::format("{}/sim_problem_0.xml", TEST_PATH),
-                                        fmt::format("{}/sim_result_0.xml", TEST_PATH), false};
+    auto qs_interface = quicksim_interface{fmt::format("{}/sim_problem_0.xml", TEST_PATH),
+                                           fmt::format("{}/sim_result_0.xml", TEST_PATH), false};
 
-    CHECK(interface.get_quicksim_params().phys_params.lambda_tf == 5);
-    CHECK(interface.get_quicksim_params().phys_params.epsilon_r == 5.6);
-    CHECK(interface.get_quicksim_params().phys_params.mu == -.25);
-    CHECK(interface.get_quicksim_params().interation_steps == 70);
-    CHECK(interface.get_quicksim_params().alpha == 0.8);
+    CHECK(qs_interface.get_quicksim_params().phys_params.lambda_tf == 5);
+    CHECK(qs_interface.get_quicksim_params().phys_params.epsilon_r == 5.6);
+    CHECK(qs_interface.get_quicksim_params().phys_params.mu == -.25);
+    CHECK(qs_interface.get_quicksim_params().interation_steps == 70);
+    CHECK(qs_interface.get_quicksim_params().alpha == 0.8);
 
-    CHECK(interface.run_simulation() == 0);
-    CHECK(!interface.get_simulation_results().valid_lyts.empty());
-    CHECK(interface.get_simulation_results().valid_lyts[0].num_cells() == 7);
+    CHECK(qs_interface.run_simulation() == 0);
+    CHECK(!qs_interface.get_simulation_results().valid_lyts.empty());
+    CHECK(qs_interface.get_simulation_results().valid_lyts[0].num_cells() == 7);
 
-    CHECK(interface.get_simulation_results().valid_lyts[0].get_cell_type({60, 23, 0}) ==
+    CHECK(qs_interface.get_simulation_results().valid_lyts[0].get_cell_type({60, 23, 0}) ==
           fiction::sidb_cell_clk_lyt_siqad::cell_type::NORMAL);
-    CHECK(interface.get_simulation_results().valid_lyts[0].get_cell_type({58, 20, 1}) ==
+    CHECK(qs_interface.get_simulation_results().valid_lyts[0].get_cell_type({58, 20, 1}) ==
           fiction::sidb_cell_clk_lyt_siqad::cell_type::NORMAL);
-    CHECK(interface.get_simulation_results().valid_lyts[0].get_cell_type({63, 21, 1}) ==
+    CHECK(qs_interface.get_simulation_results().valid_lyts[0].get_cell_type({63, 21, 1}) ==
           fiction::sidb_cell_clk_lyt_siqad::cell_type::NORMAL);
-    CHECK(interface.get_simulation_results().valid_lyts[0].get_cell_type({57, 24, 1}) ==
+    CHECK(qs_interface.get_simulation_results().valid_lyts[0].get_cell_type({57, 24, 1}) ==
           fiction::sidb_cell_clk_lyt_siqad::cell_type::NORMAL);
-    CHECK(interface.get_simulation_results().valid_lyts[0].get_cell_type({56, 23, 0}) ==
+    CHECK(qs_interface.get_simulation_results().valid_lyts[0].get_cell_type({56, 23, 0}) ==
           fiction::sidb_cell_clk_lyt_siqad::cell_type::NORMAL);
-    CHECK(interface.get_simulation_results().valid_lyts[0].get_cell_type({53, 21, 1}) ==
+    CHECK(qs_interface.get_simulation_results().valid_lyts[0].get_cell_type({53, 21, 1}) ==
           fiction::sidb_cell_clk_lyt_siqad::cell_type::NORMAL);
-    CHECK(interface.get_simulation_results().valid_lyts[0].get_cell_type({50, 24, 0}) ==
+    CHECK(qs_interface.get_simulation_results().valid_lyts[0].get_cell_type({50, 24, 0}) ==
           fiction::sidb_cell_clk_lyt_siqad::cell_type::NORMAL);
 
-    interface.write_sim_results();
+    qs_interface.write_sim_results();
 
     CHECK(std::filesystem::exists(fmt::format("{}/sim_result_0.xml", TEST_PATH)));
 }

--- a/test/interface.cpp
+++ b/test/interface.cpp
@@ -14,8 +14,8 @@
 
 TEST_CASE("Test if reading, simulating, and creating a result-file works", "[interface]")
 {
-    quicksim_interface interface(fmt::format("{}/sim_problem_0.xml", TEST_PATH),
-                                 fmt::format("{}/sim_result_0.xml", TEST_PATH), false);
+    auto interface = quicksim_interface{fmt::format("{}/sim_problem_0.xml", TEST_PATH),
+                                        fmt::format("{}/sim_result_0.xml", TEST_PATH), false};
 
     CHECK(interface.get_quicksim_params().phys_params.lambda_tf == 5);
     CHECK(interface.get_quicksim_params().phys_params.epsilon_r == 5.6);


### PR DESCRIPTION
TBB on `choco` seems to be broken. We do not need it for MSVC, but only for `clang`-based Windows builds. And even there, it is questionable whether it'd work properly. I, therefore, propose leaving it out of the workflow on Windows and compiling a possible binary release in the future with MSVC. 

This PR also fixes Boost integration in the Windows CI.