### PR TITLE
Unit change in fiction

### DIFF
--- a/src/interface.hpp
+++ b/src/interface.hpp
@@ -15,6 +15,7 @@
 #include <fiction/technology/charge_distribution_surface.hpp>
 #include <fiction/traits.hpp>
 #include <fiction/types.hpp>
+#include <fiction/utils/math_utils.hpp>
 
 #include <fmt/format.h>
 
@@ -54,14 +55,14 @@ class quicksim_interface
     void write_sim_results()
     {
         // create the vector of strings for the db locations
-        const auto data = sim_results.valid_lyts.front().get_all_sidb_location_in_nm();
+        const auto data = sim_results.valid_lyts.front().get_all_sidb_locations_in_nm();
 
         std::vector<std::pair<std::string, std::string>> dbl_data{};
         dbl_data.reserve(data.size());
 
         for (const auto& d : data)
         {
-            dbl_data.emplace_back(std::to_string(d.first * 10E9), std::to_string(d.second * 10E9));
+            dbl_data.emplace_back(std::to_string(d.first * 10), std::to_string(d.second * 10));
         }
 
         sqconn->setExport("db_loc", dbl_data);
@@ -150,8 +151,9 @@ class quicksim_interface
             // variables: physical
             params.mu = std::stod(sqconn->getParameter("muzm"));
 
-            params.epsilon_r = std::round(std::stod(sqconn->getParameter("eps_r")) * 100) / 100;  // round to two digits
-            params.lambda_tf = std::stod(sqconn->getParameter("debye_length")) * 1E-9;
+            params.epsilon_r =
+                fiction::round_to_n_decimal_places(std::stod(sqconn->getParameter("eps_r")), 2);  // round to two digits
+            params.lambda_tf = std::stod(sqconn->getParameter("debye_length"));
 
             auto_fail = std::stoi(sqconn->getParameter("autofail"));
 

--- a/test/interface.cpp
+++ b/test/interface.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Test if reading, simulating, and creating a result-file works", "[int
                                            fmt::format("{}/sim_result_0.xml", TEST_PATH), false};
 
     CHECK_THAT(qs_interface.get_quicksim_params().phys_params.lambda_tf,
-               Catch::Matchers::WithinAbs(5 * 10E-9, fiction::physical_constants::POP_STABILITY_ERR));
+               Catch::Matchers::WithinAbs(5, fiction::physical_constants::POP_STABILITY_ERR));
     CHECK(qs_interface.get_quicksim_params().phys_params.epsilon_r == 5.6);
     CHECK(qs_interface.get_quicksim_params().phys_params.mu == -.25);
     CHECK(qs_interface.get_quicksim_params().interation_steps == 70);


### PR DESCRIPTION
Since some functions are changed in fiction regarding their unit, small changes were required (e.g. ``nm``instead of ``m``).